### PR TITLE
Framework for extending Ace session state

### DIFF
--- a/plugins/c9.ide.ace/ace.js
+++ b/plugins/c9.ide.ace/ace.js
@@ -1936,6 +1936,13 @@ define(function(require, exports, module) {
                     state: session.bgTokenizer.states[row - 1],
                     mode: session.$mode.$id
                 };
+
+                state.extensionData = {};
+
+                // Any additional state given by ace extensions
+                for (key in dataExtensionHandlers) {
+                    state.extensionData[key] = dataExtensionHandlers[key].getState(session, doc);
+                }
             }
             
             function setState(doc, state) {
@@ -2021,6 +2028,11 @@ define(function(require, exports, module) {
                     
                     ace.on("changeSession", listen);
                     session.on("unload", clean);
+                }
+
+                // Any additional state given by ace extensions
+                for (key in dataExtensionHandlers) {
+                    dataExtensionHandlers[key].setState(state.extensionData[key]);
                 }
             }
             
@@ -2657,6 +2669,24 @@ define(function(require, exports, module) {
              * @param {Number}   [state.jump.select.column]             The column to select to (0 based)
              */
             plugin.freezePublicAPI({
+                /*
+                 * Register a data extension handler, which will add
+                 * extra information to a serialized Ace editor session,
+                 * for plugins that modify the Ace editor.
+                 */
+                addDataExtensionHandler: function(name, getState, setState) {
+                    if (name in dataExtensionHandlers) {
+                        return false;
+                    }
+                    else {
+                        dataExtensionHandlers[name] = {
+                            getState: getState,
+                            setState: setState
+                        }
+                        return true;
+                    }
+                },
+
                 /**
                  * @ignore
                  */

--- a/plugins/c9.ide.ace/ace.js
+++ b/plugins/c9.ide.ace/ace.js
@@ -1558,7 +1558,23 @@ define(function(require, exports, module) {
          * @extends Plugin
          * @singleton
          */
+
+        var extensionID = 0,
+            serializerExtensions = {},
+            deserializerExtensions = {};
+
         handle.freezePublicAPI({
+            /*
+             * Register a data extension handler, which will add
+             * extra information to a serialized Ace editor session,
+             * for plugins that modify the Ace editor.
+             */
+            extendSerializedState: function(serialize, deserialize) {
+                var id = extensionID++;
+                serializerExtensions[id] = serialize;
+                deserializerExtensions[id] = deserialize;
+            },
+
             /**
              * The context menu that is displayed when right clicked in the ace
              * editing area.
@@ -1574,7 +1590,7 @@ define(function(require, exports, module) {
              * @readonly
              */
             get gutterContextMenu(){ draw(); return mnuGutter },
-            
+
             /**
              * Ace Themes
              * @property {Object} themese
@@ -1888,7 +1904,7 @@ define(function(require, exports, module) {
                     renderer.$updateSizeAsync();
                 }
             }
-            
+
             function getState(doc, state, filter) {
                 if (filter) return;
                 
@@ -1940,8 +1956,8 @@ define(function(require, exports, module) {
                 state.extensionData = {};
 
                 // Any additional state given by ace extensions
-                for (key in dataExtensionHandlers) {
-                    state.extensionData[key] = dataExtensionHandlers[key].getState(session, doc);
+                for (key in serializerExtensions) {
+                    state.extensionData[key] = serializerExtensions[key](session, doc);
                 }
             }
             
@@ -2031,8 +2047,10 @@ define(function(require, exports, module) {
                 }
 
                 // Any additional state given by ace extensions
-                for (key in dataExtensionHandlers) {
-                    dataExtensionHandlers[key].setState(state.extensionData[key]);
+                for (key in deserializerExtensions) {
+                    if ('extensionData' in state && key in state.extensionData) {
+                        deserializerExtensions[key](state.extensionData[key], doc.getSession().session);
+                    }
                 }
             }
             
@@ -2669,23 +2687,6 @@ define(function(require, exports, module) {
              * @param {Number}   [state.jump.select.column]             The column to select to (0 based)
              */
             plugin.freezePublicAPI({
-                /*
-                 * Register a data extension handler, which will add
-                 * extra information to a serialized Ace editor session,
-                 * for plugins that modify the Ace editor.
-                 */
-                addDataExtensionHandler: function(name, getState, setState) {
-                    if (name in dataExtensionHandlers) {
-                        return false;
-                    }
-                    else {
-                        dataExtensionHandlers[name] = {
-                            getState: getState,
-                            setState: setState
-                        }
-                        return true;
-                    }
-                },
 
                 /**
                  * @ignore


### PR DESCRIPTION
Droplet needs a way for plugins that modify Ace behavior to add information to the serialized session state that Ace persists between refreshes. This adds the following public API method:

```
ace.extendSerializedState(
function serialize(aceSession) {
  return someObject; 
},
function deserialize(someObject, aceSession) {
  // take someObject stored by previous function and modify the session accordingly
}
```

This should also be useful for other plugins that want to add persistent functionality to the default Ace plugin.

@kzidane @dmalan 
